### PR TITLE
feat(lytfs): allow fetching from repo and branch

### DIFF
--- a/cmd/lytfs/main.go
+++ b/cmd/lytfs/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/google/go-github/v55/github"
@@ -12,13 +13,15 @@ import (
 )
 
 var (
-	timeout = flag.Duration("timeout", 5*time.Second, "timeout for fetching data; default: 5s")
+	timeout = flag.Duration("timeout", 5*time.Second, "timeout for fetching data.")
+	repo    = flag.String("repo", "botlabs-gg/yagpdb", "GitHub repository to fetch data from.")
+	branch  = flag.String("branch", "master", "GitHub branch to fetch data from.")
 )
 
 func usage() {
 	fmt.Fprintln(os.Stderr, `lytfs: list available YAGPDB template function names
 	
-usage: lytfs [-timeout duration]
+usage: lytfs [-timeout duration] [-repo owner/repo] [-branch branch]
 
 To authenticate your requests, pass a GitHub personal access token via the LYTFS_GITHUB_TOKEN environment variable.`)
 	flag.PrintDefaults()
@@ -31,9 +34,12 @@ func main() {
 	ctx, cancel := context.WithTimeout(context.Background(), *timeout)
 	defer cancel()
 
+	owner := strings.Split(*repo, "/")[0]
+	repo := strings.Split(*repo, "/")[1]
+
 	fcp := yagfuncdata.DefaultFileContentProvider
 	if token := os.Getenv("LYTFS_GITHUB_TOKEN"); token != "" {
-		fcp = yagfuncdata.NewGitHubFileProvider(github.NewClient(nil).WithAuthToken(token), "botlabs-gg", "yagpdb", "master")
+		fcp = yagfuncdata.NewGitHubFileProvider(github.NewClient(nil).WithAuthToken(token), owner, repo, *branch)
 	}
 	sources := yagfuncdata.DefaultSources(fcp)
 	funcs, err := yagfuncdata.Fetch(ctx, sources)

--- a/cmd/lytfs/main.go
+++ b/cmd/lytfs/main.go
@@ -5,7 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"strings"
+	"regexp"
 	"time"
 
 	"github.com/google/go-github/v55/github"
@@ -14,14 +14,12 @@ import (
 
 var (
 	timeout = flag.Duration("timeout", 5*time.Second, "timeout for fetching data.")
-	repo    = flag.String("repo", "botlabs-gg/yagpdb", "GitHub repository to fetch data from.")
-	branch  = flag.String("branch", "master", "GitHub branch to fetch data from.")
 )
 
 func usage() {
 	fmt.Fprintln(os.Stderr, `lytfs: list available YAGPDB template function names
 	
-usage: lytfs [-timeout duration] [-repo owner/repo] [-branch branch]
+usage: lytfs [owner/repo@branch] [-timeout duration]
 
 To authenticate your requests, pass a GitHub personal access token via the LYTFS_GITHUB_TOKEN environment variable.`)
 	flag.PrintDefaults()
@@ -34,13 +32,28 @@ func main() {
 	ctx, cancel := context.WithTimeout(context.Background(), *timeout)
 	defer cancel()
 
-	owner := strings.Split(*repo, "/")[0]
-	repo := strings.Split(*repo, "/")[1]
+	owner := "botlabs-gg"
+	repo := "yagpdb"
+	branch := "master"
 
-	fcp := yagfuncdata.NewGitHubFileProvider(github.NewClient(nil), owner, repo, *branch)
+	target := flag.Arg(0)
+	if target != "" {
+		var targetRegex = regexp.MustCompile(`^([^/]+)/([^@]+)@(.+)$`)
+		matches := targetRegex.FindStringSubmatch(target)
+		if len(matches) != 4 {
+			fmt.Fprintln(os.Stderr, "invalid target format")
+			os.Exit(1)
+		}
+
+		owner = matches[1]
+		repo = matches[2]
+		branch = matches[3]
+	}
+
+	fcp := yagfuncdata.NewGitHubFileProvider(github.NewClient(nil), owner, repo, branch)
 
 	if token := os.Getenv("LYTFS_GITHUB_TOKEN"); token != "" {
-		fcp = yagfuncdata.NewGitHubFileProvider(github.NewClient(nil).WithAuthToken(token), owner, repo, *branch)
+		fcp = yagfuncdata.NewGitHubFileProvider(github.NewClient(nil).WithAuthToken(token), owner, repo, branch)
 	}
 
 	sources := yagfuncdata.DefaultSources(fcp)

--- a/cmd/lytfs/main.go
+++ b/cmd/lytfs/main.go
@@ -37,10 +37,12 @@ func main() {
 	owner := strings.Split(*repo, "/")[0]
 	repo := strings.Split(*repo, "/")[1]
 
-	fcp := yagfuncdata.DefaultFileContentProvider
+	fcp := yagfuncdata.NewGitHubFileProvider(github.NewClient(nil), owner, repo, *branch)
+
 	if token := os.Getenv("LYTFS_GITHUB_TOKEN"); token != "" {
 		fcp = yagfuncdata.NewGitHubFileProvider(github.NewClient(nil).WithAuthToken(token), owner, repo, *branch)
 	}
+
 	sources := yagfuncdata.DefaultSources(fcp)
 	funcs, err := yagfuncdata.Fetch(ctx, sources)
 	if err != nil {


### PR DESCRIPTION
Allow specifying a target repository and branch to fetch from.

This may be useful for users running a selfhosted version of YAGPDB and
wanting to grab their instance's functions list, or just the development
version of the upstream repository.

Signed-off-by: Luca Zeuch <l-zeuch@email.de>
